### PR TITLE
optimización de abrir y cerrar el sidebar, y arreglo del asistenteia

### DIFF
--- a/src/app/dashboard/asistenteia/page.tsx
+++ b/src/app/dashboard/asistenteia/page.tsx
@@ -94,7 +94,7 @@ export default function AsistenteVirtualPage() {
   };
 
   return (
-    <div className='flex flex-col h-[calc(100vh-10rem)] max-w-4xl mx-auto bg-slate-50 border rounded-lg shadow-xl'>
+    <div className='flex flex-col h-full max-w-4xl mx-auto bg-slate-50 border rounded-lg shadow-xl'>
       <div className='flex items-center p-4 border-b bg-white rounded-t-lg'>
         {/* ▼▼▼ 1. IMAGEN EN LA CABECERA ▼▼▼ */}
         <Avatar className='h-10 w-10 mr-4'>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -4,7 +4,7 @@ import { HeaderProvider } from '@/context/HeaderContext';
 import { ProtectedRoute } from '@/components/ProtectedRoute';
 import { PopupManager } from '@/components/PopupManager';
 import { LogoutConfirmationDialog } from '@/components/LogoutConfirmationDialog';
-import { SessionManager } from '@/components/SessionManager'; // <-- Importa el nuevo componente
+import { SessionManager } from '@/components/SessionManager';
 
 export default function DashboardLayout({
   children,
@@ -15,11 +15,14 @@ export default function DashboardLayout({
     <ProtectedRoute>
       <HeaderProvider>
         <div
-          id='outer-container'
+          /*id='outer-container'*/
           className='flex h-screen overflow-hidden bg-body-dashboard text-gray-800'
         >
           <AppSidebar />
-          <div id='page-wrap' className='flex flex-1 flex-col overflow-hidden'>
+          <div
+            /*id='page-wrap'*/
+            className='flex flex-1 flex-col overflow-hidden'
+          >
             <Header />
             <main className='flex-1 overflow-y-auto p-4 md:p-6 lg:p-8'>
               {children}
@@ -28,7 +31,7 @@ export default function DashboardLayout({
         </div>
         <LogoutConfirmationDialog />
         <PopupManager />
-        <SessionManager /> {/* <-- Añade el gestor de sesión aquí */}
+        <SessionManager />
       </HeaderProvider>
     </ProtectedRoute>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -314,7 +314,13 @@ export default function AppSidebar() {
   return (
     <Sheet open={isMobileMenuOpen} onOpenChange={setMobileMenuOpen}>
       {/* El SheetTrigger vive en el Header, por lo que aquí no se necesita */}
-      <SheetContent side='left' className='flex flex-col p-0 w-64 bg-white'>
+      <SheetContent
+        side='left'
+        className={cn(
+          'flex flex-col p-0 w-64 bg-white',
+          'will-change-transform'
+        )}
+      >
         {/* --- CAMBIO 4: Solución al error de accesibilidad --- */}
         {/* Añadimos un título y descripción ocultos para los lectores de pantalla */}
         <SheetHeader className='sr-only'>


### PR DESCRIPTION
Optimizar abrir y cerrar del sidebar, ya que tenia una animación o visualización al abrir y cerrar de lentitud, que solo ocurre en versión mobile responsive en un teléfono.
Fix en la interfaz de asistente IA, la cual apenas se ingresa desde versión movil la app, se sube por completo el chat del asistente, quitando de la interfaz el Header.tsx.